### PR TITLE
Update to the modern way of cloning a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Installation
 
 ```
-git clone git://github.com/dhh/textmate-rails-bundle ~/Library/Application\ Support/TextMate/Bundles/dhh-ruby.tmbundle
+git clone git@github.com:dhh/textmate-rails-bundle.git ~/Library/Application\ Support/TextMate/Bundles/dhh-ruby.tmbundle 
 ```


### PR DESCRIPTION
* Github deprecated the syntax in readme, it just times out now. This updated syntax works fine